### PR TITLE
build: Move LDFLAGS to appear after objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,15 +212,15 @@ CTF_DEPS= $(CTF_OBJS:.o=.d)
 ifeq ($(OSTYPE), Windows)
 release/game.dll : $(CTF_OBJS)
 	@echo "===> LD $@"
-	$(Q)$(CC) $(LDFLAGS) -o $@ $(CTF_OBJS)
+	$(Q)$(CC) -o $@ $(CTF_OBJS) $(LDFLAGS)
 else ifeq ($(OSTYPE), Darwin)
 release/game.dylib : $(CTF_OBJS)
 	@echo "===> LD $@"
-	${Q}$(CC) $(LDFLAGS) -o $@ $(CTF_OBJS)
+	${Q}$(CC) -o $@ $(CTF_OBJS) $(LDFLAGS)
 else
 release/game.so : $(CTF_OBJS)
 	@echo "===> LD $@"
-	$(Q)$(CC) $(LDFLAGS) -o $@ $(CTF_OBJS)
+	$(Q)$(CC) -o $@ $(CTF_OBJS) $(LDFLAGS)
 endif
  
 # ----------


### PR DESCRIPTION
Linkers operate in order, with later objects on the command-line
providing definitions of symbols that are undefined in earlier objects.
As a result they expect to see dependent objects first, followed by
their dependencies.

Historically, this has been avoided by over-linking: with -lm in LDFLAGS,
the object was given an (at the time) unnecessary dependency on libm,
which later becomes necessary when the object files are added.

However, to reduce unnecessary dependencies and simplify the dependency
graph, some distributions' compilers (including Ubuntu and Fedora)
default to linking with the equivalent of -Wl,--as-needed, which defeats
that. As a result, now that we link with -lm, the build fails on those
linkers unless we move -lm to appear after the objects that depend on it.

---

Moving the `LDFLAGS` to the end is consistent with how this works in yquake2.

If you would prefer to revert 8c582738, that would be another way to fix this.

Separating the `LDFLAGS` into `LDFLAGS` (global behaviour modifiers for the linker) and `LDLIBS` (dependencies), like the way it's done in GNU make's default built-in rules, Autotools and various other build systems, would also work:

```
LDFLAGS := -shared
LDLIBS := -lm

...

        $(Q)$(CC) $(LDFLAGS) -o $@ $(CTF_OBJS) $(LDLIBS)
```

which is a simple change here, but would be more intrusive if applied to yquake2.