### PR TITLE
Implement accurate-aiming CVAR in ctf game code.

### DIFF
--- a/src/g_ctf.c
+++ b/src/g_ctf.c
@@ -1718,8 +1718,7 @@ CTFGrappleDrawCable(edict_t *self)
 
 	AngleVectors(self->owner->client->v_angle, f, r, NULL);
 	VectorSet(offset, 16, 16, self->owner->viewheight - 8);
-	P_ProjectSource(self->owner->client, self->owner->s.origin,
-			offset, f, r, start);
+	P_ProjectSource(self->owner, offset, f, r, start);
 
 	VectorSubtract(start, self->owner->s.origin, offset);
 
@@ -1903,7 +1902,7 @@ CTFGrappleFire(edict_t *ent, vec3_t g_offset, int damage, int effect)
 	AngleVectors(ent->client->v_angle, forward, right, NULL);
 	VectorSet(offset, 24, 8, ent->viewheight - 8 + 2);
 	VectorAdd(offset, g_offset, offset);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	VectorScale(forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;

--- a/src/g_main.c
+++ b/src/g_main.c
@@ -77,6 +77,8 @@ cvar_t *flood_waitdelay;
 
 cvar_t *sv_maplist;
 
+cvar_t *aimfix;
+
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);
 qboolean ClientConnect(edict_t *ent, char *userinfo);

--- a/src/g_save.c
+++ b/src/g_save.c
@@ -204,6 +204,9 @@ InitGame(void)
 	/* dm map list */
 	sv_maplist = gi.cvar("sv_maplist", "", 0);
 
+	/* others */
+	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
+
 	/* items */
 	InitItems();
 

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -541,6 +541,8 @@ extern cvar_t *flood_waitdelay;
 
 extern cvar_t *sv_maplist;
 
+extern cvar_t *aimfix;
+
 #define world (&g_edicts[0])
 
 /* item spawnflags */
@@ -760,7 +762,7 @@ void DeathmatchScoreboardMessage(edict_t *client, edict_t *killer);
 
 /* g_pweapon.c */
 void PlayerNoise(edict_t *who, vec3_t where, int type);
-void P_ProjectSource(gclient_t *client, vec3_t point, vec3_t distance,
+void P_ProjectSource(edict_t *ent, vec3_t distance,
 		vec3_t forward, vec3_t right, vec3_t result);
 void Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 		int FRAME_IDLE_LAST, int FRAME_DEACTIVATE_LAST, int *pause_frames,

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -33,10 +33,12 @@ static byte is_silenced;
 void weapon_grenade_fire(edict_t *ent, qboolean held);
 
 void
-P_ProjectSource(gclient_t *client, vec3_t point, vec3_t distance,
+P_ProjectSource(edict_t *ent, vec3_t distance,
 		vec3_t forward, vec3_t right, vec3_t result)
 {
-	vec3_t _distance;
+	gclient_t *client = ent->client;
+	float     *point  = ent->s.origin;
+	vec3_t     _distance;
 
 	VectorCopy(distance, _distance);
 
@@ -50,6 +52,21 @@ P_ProjectSource(gclient_t *client, vec3_t point, vec3_t distance,
 	}
 
 	G_ProjectSource(point, _distance, forward, right, result);
+
+	// Berserker: fix - now the projectile hits exactly where the scope is pointing.
+	if (aimfix->value)
+	{
+		vec3_t start, end;
+		VectorSet(start, ent->s.origin[0], ent->s.origin[1], ent->s.origin[2] + ent->viewheight);
+		VectorMA(start, 8192, forward, end);
+
+		trace_t	tr = gi.trace(start, NULL, NULL, end, ent, MASK_SHOT);
+		if (tr.fraction < 1)
+		{
+			VectorSubtract(tr.endpos, result, forward);
+			VectorNormalize(forward);
+		}
+	}
 }
 
 /*
@@ -659,7 +676,7 @@ weapon_grenade_fire(edict_t *ent, qboolean held)
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
 	AngleVectors(ent->client->v_angle, forward, right, NULL);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	timer = ent->client->grenade_time - level.time;
 	speed = GRENADE_MINSPEED + (GRENADE_TIMER -
@@ -848,7 +865,7 @@ weapon_grenadelauncher_fire(edict_t *ent)
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
 	AngleVectors(ent->client->v_angle, forward, right, NULL);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	VectorScale(forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;
@@ -913,7 +930,7 @@ Weapon_RocketLauncher_Fire(edict_t *ent)
 	ent->client->kick_angles[0] = -1;
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_rocket(ent, start, forward, damage, 650, damage_radius, radius_damage);
 
 	/* send muzzle flash */
@@ -966,7 +983,7 @@ Blaster_Fire(edict_t *ent, vec3_t g_offset, int damage,
 	AngleVectors(ent->client->v_angle, forward, right, NULL);
 	VectorSet(offset, 24, 8, ent->viewheight - 8);
 	VectorAdd(offset, g_offset, offset);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	VectorScale(forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;
@@ -1200,7 +1217,7 @@ Machinegun_Fire(edict_t *ent)
 	VectorAdd(ent->client->v_angle, ent->client->kick_angles, angles);
 	AngleVectors(angles, forward, right, NULL);
 	VectorSet(offset, 0, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_bullet(ent, start, forward, damage, kick,
 			DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD,
 			MOD_MACHINEGUN);
@@ -1367,8 +1384,7 @@ Chaingun_Fire(edict_t *ent)
 		r = 7 + crandom() * 4;
 		u = crandom() * 4;
 		VectorSet(offset, 0, r, u + ent->viewheight - 8);
-		P_ProjectSource(ent->client, ent->s.origin, offset,
-				forward, right, start);
+		P_ProjectSource(ent, offset, forward, right, start);
 
 		fire_bullet(ent, start, forward, damage, kick,
 				DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD,
@@ -1427,7 +1443,7 @@ weapon_shotgun_fire(edict_t *ent)
 	ent->client->kick_angles[0] = -2;
 
 	VectorSet(offset, 0, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	if (is_quad)
 	{
@@ -1487,7 +1503,7 @@ weapon_supershotgun_fire(edict_t *ent)
 	ent->client->kick_angles[0] = -2;
 
 	VectorSet(offset, 0, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	if (is_quad)
 	{
@@ -1573,7 +1589,7 @@ weapon_railgun_fire(edict_t *ent)
 	ent->client->kick_angles[0] = -3;
 
 	VectorSet(offset, 0, 7, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_rail(ent, start, forward, damage, kick);
 
 	/* send muzzle flash */
@@ -1663,7 +1679,7 @@ weapon_bfg_fire(edict_t *ent)
 	ent->client->v_dmg_time = level.time + DAMAGE_TIME;
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_bfg(ent, start, forward, damage, 400, damage_radius);
 
 	ent->client->ps.gunframe++;


### PR DESCRIPTION
CTF-specific implementation of the changes in baseq2 PR [#561](https://github.com/yquake2/yquake2/pull/561).

This has been successfully build locally with GCC 9.3.0 but not gameplay tested as I don't have the PAK file on-hand.