### PR TITLE
Fix wrong team announce on flag return

### DIFF
--- a/src/g_misc.c
+++ b/src/g_misc.c
@@ -334,7 +334,7 @@ BecomeExplosion1(edict_t *self)
 	{
 		CTFResetFlag(CTF_TEAM2); /* this will free self! */
 		gi.bprintf(PRINT_HIGH, "The %s flag has returned!\n",
-				CTFTeamName(CTF_TEAM1));
+				CTFTeamName(CTF_TEAM2));
 		return;
 	}
 


### PR DESCRIPTION
Fix wrong team being announced when the blue flag is returned after it gets destroyed.

Before:
```
[PDL]TOMMYROT got the BLUE flag!
[PDL]TOMMYROT was in the wrong place.
[PDL]TOMMYROT lost the BLUE flag!
The RED flag has returned!
```

After:
```
[PDL]TOMMYROT got the BLUE flag!
[PDL]TOMMYROT was in the wrong place.
[PDL]TOMMYROT lost the BLUE flag!
The BLUE flag has returned!
```