### PR TITLE
Bring more in line with rogue/xatrix, fix build warning

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -106,10 +106,14 @@ ShutdownGame(void)
 }
 
 /*
- * Returns a pointer to the structure with
- * all entry points and global variables
- */
-game_export_t *
+=================
+GetGameAPI
+
+Returns a pointer to the structure with all entry points
+and global variables
+=================
+*/
+Q2_DLL_EXPORTED game_export_t *
 GetGameAPI(game_import_t *import)
 {
 	gi = *import;

--- a/src/header/shared.h
+++ b/src/header/shared.h
@@ -54,7 +54,42 @@ typedef unsigned char byte;
 #define MAX_TOKEN_CHARS 128         /* max length of an individual token */
 
 #define MAX_QPATH 64                /* max length of a quake game pathname */
-#define MAX_OSPATH 128              /* max length of a filesystem pathname */
+
+/*
+ * DG: For some stupid reason, SV_WriteServerFile() and SV_ReadeServerFile() used
+ * MAX_OSPATH as buffer length for CVAR_LATCH CVARS and saved the whole buffer
+ * into $game/save/current/server.ssv, so changing MAX_OSPATH breaks savegames...
+ * Unfortunately, for some other fucking reason MAX_OSPATH was 128 for non-Windows
+ * which is just horrible.. so I introduced LATCH_CVAR_SAVELENGTH with the stupid
+ * values so I could bump MAX_OSPATH.
+ * TODO: whenever you break savegame compatibility next, make
+ *       LATCH_CVAR_SAVELENGTH system-independent (or remove it and hardcode a
+ *       sensible value in the two functions)
+ */
+
+#ifdef _WIN32
+ #define MAX_OSPATH 256             /* max length of a filesystem pathname (same as MAX_PATH) */
+ #define LATCH_CVAR_SAVELENGTH 256
+
+ // by default dlls don't export any functions, use this to
+ // make a function visible (for GetGameAPI(), GetRefAPI() and similar)
+ #define Q2_DLL_EXPORTED  __declspec(dllexport)
+
+#else // not Win32 (Linux, BSD, Mac, ..)
+
+ #define MAX_OSPATH 4096            /* max length of a filesystem pathname */
+ #define LATCH_CVAR_SAVELENGTH 128
+
+ // by default our .so/.dylibs don't export any functions, use this to
+ // make a function visible (for GetGameAPI(), GetRefAPI() and similar)
+ #define Q2_DLL_EXPORTED  __attribute__((__visibility__("default")))
+#endif
+
+#ifdef _MSC_VER
+ #define PRINTF_ATTR(FMT, VARGS)
+#else // at least GCC/mingw and clang support this
+ #define PRINTF_ATTR(FMT, VARGS) __attribute__((format(printf, FMT , VARGS )))
+#endif
 
 /* */
 /* per-level limits */

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -290,14 +290,10 @@ R_ConcatTransforms(float in1[3][4], float in2[3][4], float out[3][4])
 float
 Q_fabs(float f)
 {
-	int i_tmp;
-	memcpy(&i_tmp, &f, sizeof(f));
+	int tmp = *(int *)&f;
 
-	i_tmp &= 0x7FFFFFFF;
-
-	float f_tmp;
-	memcpy(&f_tmp, &i_tmp, sizeof(i_tmp));
-	return f_tmp;
+	tmp &= 0x7FFFFFFF;
+	return *(float *)&tmp;
 }
 
 float

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -290,10 +290,14 @@ R_ConcatTransforms(float in1[3][4], float in2[3][4], float out[3][4])
 float
 Q_fabs(float f)
 {
-	int tmp = *(int *)&f;
+	int i_tmp;
+	memcpy(&i_tmp, &f, sizeof(f));
 
-	tmp &= 0x7FFFFFFF;
-	return *(float *)&tmp;
+	i_tmp &= 0x7FFFFFFF;
+
+	float f_tmp;
+	memcpy(&f_tmp, &i_tmp, sizeof(i_tmp));
+	return f_tmp;
 }
 
 float

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -1027,9 +1027,9 @@ Com_PageInMemory(byte *buffer, int size)
  */
 
 int
-Q_stricmp(const char *s1, const char *s2)
+Q_stricmp(const char* s1, const char* s2)
 {
-	return strcasecmp(s1, s2);
+	return Q_strcasecmp((char*)s1, (char*)s2);
 }
 
 int


### PR DESCRIPTION
Changes:

- dll import in line with rogue/xatrix
- use Use Q_strncasecmp in line with rogue/xatrix
